### PR TITLE
Hide font preloader span from screen readers

### DIFF
--- a/includes/class-script-generator.php
+++ b/includes/class-script-generator.php
@@ -170,7 +170,7 @@ if ( !class_exists( 'FooBox_Free_Script_Generator' ) ) {
 			$ready_event = 'FooBox.ready';
 
 			$preload = '  //preload the foobox font
-  jQuery("body").append("<span style=\"font-family:\'foobox\'; color:transparent; position:absolute; top:-1000em;\">f</span>");';
+  jQuery("body").append("<span style=\"font-family:\'foobox\'; color:transparent; position:absolute; top:-1000em;\" aria-hidden="true">f</span>");';
 
 			$js .= '
   };


### PR DESCRIPTION
Add `aria-hidden` attribute to the `span` used to preload the foobox
font. This element is invisible to sighted users but is read by screen
readers simply as `f`. `aria-hidden` will make it invisible to screen
readers as well.